### PR TITLE
Fix export to JPEG

### DIFF
--- a/freehep-graphicsio/src/main/java/org/freehep/graphicsio/ImageGraphics2D.java
+++ b/freehep-graphicsio/src/main/java/org/freehep/graphicsio/ImageGraphics2D.java
@@ -348,7 +348,8 @@ public class ImageGraphics2D extends PixelGraphics2D {
         }
 
         // NOTE: special case for JPEG which has no Alpha
-        if (ImageConstants.JPG.equalsIgnoreCase(format)) {
+        if (ImageConstants.JPG.equalsIgnoreCase(format)
+		|| ImageConstants.JPEG.equalsIgnoreCase(format)) {
             return new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         }
 


### PR DESCRIPTION
The JPEG format exports files with alpha because only JPG extension is managed.
