### PR TITLE
[EMF] Little improve of freehep-graphicsio-emf for font quality and image ratio.

### DIFF
--- a/freehep-graphicsio-emf/src/main/java/org/freehep/graphicsio/emf/EMFHeader.java
+++ b/freehep-graphicsio-emf/src/main/java/org/freehep/graphicsio/emf/EMFHeader.java
@@ -12,7 +12,7 @@ import java.io.IOException;
  * @version $Id: freehep-graphicsio-emf/src/main/java/org/freehep/graphicsio/emf/EMFHeader.java 39340faa2114 2007/02/12 08:14:31 duns $
  */
 public class EMFHeader implements EMFConstants {
-    private static final Dimension screenMM = new Dimension(320, 240);
+    public static final Dimension screenMM = new Dimension(320, 240);
 
     private Rectangle bounds;
 

--- a/freehep-graphicsio-emf/src/main/java/org/freehep/graphicsio/emf/gdi/LogFontW.java
+++ b/freehep-graphicsio-emf/src/main/java/org/freehep/graphicsio/emf/gdi/LogFontW.java
@@ -82,7 +82,7 @@ public class LogFontW implements EMFConstants, GDIObject {
         this.charSet = 0; // ANSI_CHARSET;
         this.outPrecision = 0; // OUT_DEFAULT_PRECIS;
         this.clipPrecision = 0; // CLIP_DEFAULT_PRECIS;
-        this.quality = 4; // ANTIALIASED_QUALITY;
+        this.quality = 5; // CLEARTYPE_QUALITY;
         this.pitchAndFamily = 0;
         this.faceFamily = font.getName();
     }


### PR DESCRIPTION
Hello,

I change the Font quality from ANTIALIASED_QUALITY (4) to CLEARTYPE_QUALITY (5), because it's look much better in word and windows standard emf viewer.

In org.freehep.graphicsio.emf.EMFHeader, I passed the static field screenMM public because by default the dimension are from a 4/3 screen and with another one (mine is 16/9) the ratio is not keeped.

Thanks.
