### PR TITLE
Allow alternative postscript prolog resources

### DIFF
--- a/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/AbstractPSGraphics2D.java
+++ b/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/AbstractPSGraphics2D.java
@@ -199,7 +199,7 @@ public abstract class AbstractPSGraphics2D extends AbstractVectorGraphicsIO impl
 
     /**
      * Write out the header of this EPS file.
-     * @param prolog name of the resource containing the 
+     * @param prolog name of the Java resource containing the 
      * prolog. Must be reachable by the ClassLoader.
      */
     public void writeHeader(String prolog) throws IOException {
@@ -233,9 +233,8 @@ public abstract class AbstractPSGraphics2D extends AbstractVectorGraphicsIO impl
             encoder.encode();
         }
 
-        // The prolog is kept in a file PSProlog.txt in the same area
-        // as this class definition. It is simply copied into the
-        // output file.
+        // The prolog is provided as a Java resource.  It is 
+        // simply copied into the output file.
         os.println("%%BeginProlog");
         copyResourceTo(this, prolog, os);
         os.println("%%EndProlog");
@@ -243,10 +242,12 @@ public abstract class AbstractPSGraphics2D extends AbstractVectorGraphicsIO impl
     }
 
     /**
-     * Write out the header of this EPS file. Use standard 
-     * PSProlog.txt file.
+     * Write out the header of this EPS file. Use the default 
+     * PSProlog.txt file provided with this package.
      */
     public void writeHeader() throws IOException {
+        // the default prolog is kept in a file PSProlog.txt in the 
+        // same area as this class definition.
         writeHeader("PSProlog.txt");
     }
 

--- a/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/AbstractPSGraphics2D.java
+++ b/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/AbstractPSGraphics2D.java
@@ -199,8 +199,10 @@ public abstract class AbstractPSGraphics2D extends AbstractVectorGraphicsIO impl
 
     /**
      * Write out the header of this EPS file.
+     * @param prolog name of the resource containing the 
+     * prolog. Must be reachable by the ClassLoader.
      */
-    public void writeHeader() throws IOException {
+    public void writeHeader(String prolog) throws IOException {
         String producer = getClass().getName();
         if (!isDeviceIndependent()) {
             producer += " " + version.substring(1, version.length() - 1);
@@ -235,9 +237,17 @@ public abstract class AbstractPSGraphics2D extends AbstractVectorGraphicsIO impl
         // as this class definition. It is simply copied into the
         // output file.
         os.println("%%BeginProlog");
-        copyResourceTo(this, "PSProlog.txt", os);
+        copyResourceTo(this, prolog, os);
         os.println("%%EndProlog");
         os.println();
+    }
+
+    /**
+     * Write out the header of this EPS file. Use standard 
+     * PSProlog.txt file.
+     */
+    public void writeHeader() throws IOException {
+        writeHeader("PSProlog.txt");
     }
 
     public void writeBackground() throws IOException {

--- a/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/EPSGraphics2D.java
+++ b/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/EPSGraphics2D.java
@@ -93,6 +93,10 @@ public class EPSGraphics2D extends AbstractPSGraphics2D {
     }
 
     public void writeHeader() throws IOException {
+        writeHeader(null);
+    }
+
+    public void writeHeader(String prolog) throws IOException {
         Dimension size = getSize();
         // moved to openPage for multiPage
         resetClip(new Rectangle(0, 0, size.width, size.height));
@@ -103,7 +107,11 @@ public class EPSGraphics2D extends AbstractPSGraphics2D {
         os.println("%%BoundingBox: " + bbox.x + " " + bbox.y + " "
                     + (bbox.x + bbox.width) + " " + (bbox.y + bbox.height));
 
-        super.writeHeader();
+        if(prolog != null) {
+            super.writeHeader(prolog);
+        } else {
+            super.writeHeader();
+	}
 
         os.println("%%BeginSetup");
 

--- a/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/PSGraphics2D.java
+++ b/freehep-graphicsio-ps/src/main/java/org/freehep/graphicsio/ps/PSGraphics2D.java
@@ -101,6 +101,10 @@ public class PSGraphics2D extends AbstractPSGraphics2D implements
     }
     
     public void writeHeader() throws IOException {
+        writeHeader(null);
+    }
+
+    public void writeHeader(String prolog) throws IOException {
         if (!isMultiPage()) {
             Dimension size = getSize();
             // moved to openPage for multiPage
@@ -110,7 +114,11 @@ public class PSGraphics2D extends AbstractPSGraphics2D implements
         os = new PrintStream(ros, true);
         os.println("%!PS-Adobe-3.0");
 
-        super.writeHeader();
+        if(prolog != null) {
+            super.writeHeader(prolog);
+        } else {
+            super.writeHeader();
+        }
 
         if (!isMultiPage())
             openPage(getSize(), null, getComponent());


### PR DESCRIPTION
I had the impression that the provided postscript header (PSProlog.txt) could be compacted by at least 30 percent. The provided header with comments and formatting is perfectly suited for development or occasional use. However there are cases, where a more compact prolog would fit better. This patch introduces the possibility to choose an alternative prolog file. To keep the changes at the absolute minimum needed, the method of including the prolog hasn't been changed. The alternative prolog file must be still provided as a Java resource.
